### PR TITLE
adds option to ignore undefined values

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,8 @@ const defineProperty = (obj, name, value) => Object.defineProperty(obj, name, {
 
 const globalThis = this;
 const defaultMergeOpts = {
-	concatArrays: false
+	concatArrays: false,
+	ignoreUndefined: false
 };
 
 const getEnumerableOwnPropertyKeys = value => {
@@ -76,6 +77,10 @@ function cloneOptionObject(obj) {
  */
 const mergeKeys = (merged, source, keys, mergeOpts) => {
 	keys.forEach(key => {
+		if (typeof source[key] === 'undefined' && mergeOpts.ignoreUndefined) {
+			return;
+		}
+
 		// Do not recurse into prototype chain of merged
 		if (key in merged && merged[key] !== Object.getPrototypeOf(merged)) {
 			defineProperty(merged, key, merge(merged[key], source[key], mergeOpts));

--- a/readme.md
+++ b/readme.md
@@ -85,6 +85,25 @@ mergeOptions.apply({concatArrays: true}, [{src: ['src/**']}, {src: ['test/**']}]
 //=> {src: ['src/**', 'test/**']}
 ```
 
+##### config.ignoreUndefined
+
+Type: `boolean`<br/>Default: `false`
+
+Ignore undefined values:
+
+```js
+mergeOptions({foo: 'bar'}, {foo: undefined})
+//=> {foo: undefined}
+
+// Via call
+mergeOptions.call({ignoreUndefined: true}, {foo: 'bar'}, {foo: undefined})
+//=> {foo: 'bar'}
+
+// Via apply
+mergeOptions.apply({ignoreUndefined: true}, [{foo: 'bar'}, {foo: undefined}])
+//=> {foo: 'bar'}
+```
+
 
 ## Related
 

--- a/test/undefined-values.js
+++ b/test/undefined-values.js
@@ -1,0 +1,16 @@
+import test from 'ava';
+import mergeOptions from '..';
+
+test('undefined values', t => {
+	t.deepEqual(
+		mergeOptions.call({ignoreUndefined: true}, {foo: 0}, {foo: undefined}),
+		{foo: 0}
+	);
+});
+
+test('deep undefined values', t => {
+	t.deepEqual(
+		mergeOptions.call({ignoreUndefined: true}, {nested: {unicorns: 'none'}}, {nested: {unicorns: undefined}}),
+		{nested: {unicorns: 'none'}}
+	);
+});

--- a/test/undefined-values.js
+++ b/test/undefined-values.js
@@ -14,3 +14,10 @@ test('deep undefined values', t => {
 		{nested: {unicorns: 'none'}}
 	);
 });
+
+test('undefined options objects', t => {
+	t.deepEqual(
+		mergeOptions.call({ignoreUndefined: true}, {nested: {unicorns: 'none'}}, {nested: undefined}),
+		{nested: {unicorns: 'none'}}
+	);
+});


### PR DESCRIPTION
It's common to take `options` arguments and pass some of them on to other functions.

If the incoming option is not set, this can result in passing `undefined` on to other functions which can cause surprise if the other function sets up its own default values.

```javascript
function someOtherFunc (options = {}) {
  options.key = options.key || 'default-value'

  console.info(options.key)
}

function someFunc (options = {}) {
  // do some work
  // ...

  return someOtherFunc(mergeOptions({
    key: 'overridden-default-value'
  }, {
    key: options.key
  }))
}

someFunc()
// prints 'default-value'
```

This PR adds a `ignoreUndefined` option to not set values to `undefined`:

```javascript
function someFunc (options = {}) {
  // do some work
  // ...

  return someOtherFunc(mergeOptions.call({ ignoreUndefined: true }, {
    key: 'overridden-default-value'
  }, {
    key: options.key
  }))
}

someFunc()
// prints 'overridden-default-value'
```

Fixes #13 
