### PR TITLE
re-add node 10 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,6 @@ node_js:
   - 'stable'
   - '14'
   - '12'
+  - '10'
 after_success:
   - './node_modules/.bin/nyc report --reporter=text-lcov | ./node_modules/.bin/coveralls'

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "email": "michael@schnittstabil.de"
   },
   "engines": {
-    "node": ">=12"
+    "node": ">=10"
   },
   "scripts": {
     "test": "xo && nyc ava",


### PR DESCRIPTION
`merge-options@3` does not add any new language syntax not available in Node 10, which has Long Term Support until [30th of April, 2021](https://nodejs.org/en/about/releases/) (8 months away).

As stated in https://github.com/schnittstabil/merge-options/issues/23#issuecomment-690982169, `merge-options@3` uses the new (12+) `exports` in `package.json` for ESM, so Node 10 will continue to use the CommonJS `main: ./index.js` entrypoint. This is the same setup as in the project I maintain that uses this package.

Blocking https://github.com/wopian/kitsu/pull/464