### PR TITLE
fix type defs

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,3 @@
 export = mergeOptions;
 
-declare function mergeOptions<T>(...options: any[]): T;
+declare function mergeOptions(...options: any[]);

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,1 +1,3 @@
-export default function (...options: any[]): any;
+export = mergeOptions;
+
+declare function mergeOptions<T>(...options: any[]): T;


### PR DESCRIPTION
Without this change I see errors such as:

```
../file.js:20:23 - error TS2339: Property 'call' does not exist on type 'typeof import("/path/to/node_modules/merge-options/index")'.

20   return mergeOptions.call(
                         ~~~~
```

and

```
../file.js:56:19 - error TS2349: This expression is not callable.
  Type 'typeof import("/path/to/node_modules/merge-options/index")' has no call signatures.

56         options = mergeOptions(constructorOptions.init, options)
                     ~~~~~~~~~~~~
```

and

```
../file.js:8:47 - error TS2339: Property 'bind' does not exist on type 'typeof import("/path/to/node_modules/merge-options/index")'.

8 const mergeOptions = require('merge-options').bind({ ignoreUndefined: true })
                                                ~~~~
```