### PR TITLE
fix: add types to exports map

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "main": "./index.js",
   "exports": {
+    "types": "./index.d.ts",
     "require": "./index.js",
     "import": "./index.mjs"
   },


### PR DESCRIPTION
To support the `Node16`/`NodeNext` module resolution strategy, the exports map needs a `"types"` entry for each export.

Docs: https://www.typescriptlang.org/tsconfig#moduleResolution